### PR TITLE
Allows adding an optional description string to customize progress message

### DIFF
--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -25,7 +25,7 @@ class ProgressRecorder(AbtractProgressRecorder):
     def __init__(self, task):
         self.task = task
 
-    def set_progress(self, current, total):
+    def set_progress(self, current, total, description=""):
         percent = 0
         if total > 0:
             percent = (Decimal(current) / Decimal(total)) * Decimal(100)
@@ -36,6 +36,7 @@ class ProgressRecorder(AbtractProgressRecorder):
                 'current': current,
                 'total': total,
                 'percent': percent,
+                'description': description
             }
         )
 

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -18,7 +18,7 @@ var CeleryProgressBar = (function () {
     function onProgressDefault(progressBarElement, progressBarMessageElement, progress) {
         progressBarElement.style.backgroundColor = '#68a9ef';
         progressBarElement.style.width = progress.percent + "%";
-        progressBarMessageElement.innerHTML = progress.current + ' of ' + progress.total + ' processed.';
+        progressBarMessageElement.innerHTML = progress.current + ' of ' + progress.total + ' processed.' + progress.description;
     }
 
     function updateProgress (progressUrl, options) {


### PR DESCRIPTION
I think it can be useful for the user to get a more verbose progress update. This PR adds support to set an optional description that is then displayed with every progress update.

`pc.set_progress(i+1, len(users), description=f"Processing user {user}.")`