### PR TITLE
adding result data to 'onSuccess' function

### DIFF
--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -1,5 +1,5 @@
 var CeleryProgressBar = (function () {
-    function onSuccessDefault(progressBarElement, progressBarMessageElement) {
+    function onSuccessDefault(progressBarElement, progressBarMessageElement, result) {
         progressBarElement.style.backgroundColor = '#76ce60';
         progressBarMessageElement.innerHTML = "Success!";
     }
@@ -46,7 +46,7 @@ var CeleryProgressBar = (function () {
                     setTimeout(updateProgress, pollInterval, progressUrl, options);
                 } else {
                     if (data.success) {
-                        onSuccess(progressBarElement, progressBarMessageElement);
+                        onSuccess(progressBarElement, progressBarMessageElement, data.result);
                     } else {
                         onError(progressBarElement, progressBarMessageElement);
                     }

--- a/celery_progress/static/celery_progress/websockets.js
+++ b/celery_progress/static/celery_progress/websockets.js
@@ -1,5 +1,5 @@
 var CeleryWebSocketProgressBar = (function () {
-    function onSuccessDefault(progressBarElement, progressBarMessageElement) {
+    function onSuccessDefault(progressBarElement, progressBarMessageElement, result) {
         CeleryProgressBar.onSuccessDefault(progressBarElement, progressBarMessageElement);
     }
 
@@ -43,7 +43,7 @@ var CeleryWebSocketProgressBar = (function () {
             }
             if (data.complete) {
                 if (data.success) {
-                    onSuccess(progressBarElement, progressBarMessageElement);
+                    onSuccess(progressBarElement, progressBarMessageElement, data.result);
                 } else {
                     onError(progressBarElement, progressBarMessageElement);
                 }


### PR DESCRIPTION
I have a use case in an application of mine which utilises celery-progress and requires a custom onSuccess function. 
This function includes logic that is conditional on the contents of _data.result_. (ie. if the string contains certain values, do something).

I've created this pull request as I believe this additional functionality may be of use to other users of this package.