### PR TITLE
More error handling in the polling client

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ The `initProgressBar` function takes an optional object of options. The followin
 | resultElement | Override the *element* used for the result. If specified, resultElementId will be ignored. | document.getElementById(resultElementId) |
 | onProgress | function to call when progress is updated | CeleryProgressBar.onProgressDefault |
 | onSuccess | function to call when progress successfully completes | CeleryProgressBar.onSuccessDefault |
-| onError | function to call when on a known error with no specified handler | CeleryProgressBar.onErrorDefault |
+| onError | function to call on a known error with no specified handler | CeleryProgressBar.onErrorDefault |
 | onTaskError | function to call when progress completes with an error | onError |
 | onNetworkError | function to call on a network error (ignored by WebSocket) | onError |
 | onHttpError | function to call on a non-200 response (ignored by WebSocket) | onError |
-| onDataError | function to call on a 200 response that's not JSON or has invalid schema due to a programming error | onError (ignored by WebSocket) |
+| onDataError | function to call on a 200 response that's not JSON or has invalid schema due to a programming error (ignored by WebSocket) | onError |
 | onResult | function to call when returned non empty result | CeleryProgressBar.onResultDefault |
 
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,11 @@ The `initProgressBar` function takes an optional object of options. The followin
 | resultElement | Override the *element* used for the result. If specified, resultElementId will be ignored. | document.getElementById(resultElementId) |
 | onProgress | function to call when progress is updated | CeleryProgressBar.onProgressDefault |
 | onSuccess | function to call when progress successfully completes | CeleryProgressBar.onSuccessDefault |
-| onError | function to call when progress completes with an error | CeleryProgressBar.onErrorDefault |
+| onError | function to call when on a known error with no specified handler | CeleryProgressBar.onErrorDefault |
+| onTaskError | function to call when progress completes with an error | onError |
+| onNetworkError | function to call on a network error (ignored by WebSocket) | onError |
+| onHttpError | function to call on a non-200 response (ignored by WebSocket) | onError |
+| onDataError | function to call on a 200 response that's not JSON or has invalid schema due to a programming error | onError (ignored by WebSocket) |
 | onResult | function to call when returned non empty result | CeleryProgressBar.onResultDefault |
 
 

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -75,7 +75,7 @@ var CeleryProgressBar = (function () {
                 } else {
                     onDataError(progressBarElement, progressBarMessageElement, "Data Error");
                 }
-                if (data.result) {
+                if (data.hasOwnProperty('result')) {
                     onResult(resultElement, data.result);
                 }
             }

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -65,13 +65,15 @@ var CeleryProgressBar = (function () {
             if (data.progress) {
                 onProgress(progressBarElement, progressBarMessageElement, data.progress);
             }
-            if (!data.complete) {
+            if (data.complete === false) {
                 setTimeout(updateProgress, pollInterval, progressUrl, options);
             } else {
-                if (data.success) {
+                if (data.success === true) {
                     onSuccess(progressBarElement, progressBarMessageElement, data.result);
-                } else {
+                } else if (data.success === false) {
                     onTaskError(progressBarElement, progressBarMessageElement, data.result);
+                } else {
+                    onDataError(progressBarElement, progressBarMessageElement, "Data Error");
                 }
                 if (data.result) {
                     onResult(resultElement, data.result);

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -22,7 +22,7 @@ var CeleryProgressBar = (function () {
         progressBarMessageElement.innerHTML = progress.current + ' of ' + progress.total + ' processed. ' + description;
     }
 
-    function updateProgress (progressUrl, options) {
+    async function updateProgress (progressUrl, options) {
         options = options || {};
         var progressBarId = options.progressBarId || 'progress-bar';
         var progressBarMessage = options.progressBarMessageId || 'progress-bar-message';
@@ -31,13 +31,22 @@ var CeleryProgressBar = (function () {
         var onProgress = options.onProgress || onProgressDefault;
         var onSuccess = options.onSuccess || onSuccessDefault;
         var onError = options.onError || onErrorDefault;
+        var onNetworkError = options.onNetworkError || onErrorDefault;
+        var onHttpError = options.onHttpError || onErrorDefault;
         var pollInterval = options.pollInterval || 500;
         var resultElementId = options.resultElementId || 'celery-result';
         var resultElement = options.resultElement || document.getElementById(resultElementId);
         var onResult = options.onResult || onResultDefault;
 
 
-        fetch(progressUrl).then(function(response) {
+        let response;
+        try {
+            response = await fetch(progressUrl);
+        } catch (networkError) {
+            onNetworkError(progressBarElement, progressBarMessageElement, "Network Error");
+        }
+
+        if (response.status === 200) {
             response.json().then(function(data) {
                 if (data.progress) {
                     onProgress(progressBarElement, progressBarMessageElement, data.progress);
@@ -55,12 +64,16 @@ var CeleryProgressBar = (function () {
                     }
                 }
             });
-        });
+        } else {
+            onHttpError(progressBarElement, progressBarMessageElement, "HTTP Code " + response.status);
+        }
     }
     return {
         onSuccessDefault: onSuccessDefault,
         onResultDefault: onResultDefault,
         onErrorDefault: onErrorDefault,
+        onNetworkError: onErrorDefault,
+        onHttpError: onErrorDefault,
         onProgressDefault: onProgressDefault,
         updateProgress: updateProgress,
         initProgressBar: updateProgress,  // just for api cleanliness

--- a/celery_progress/static/celery_progress/websockets.js
+++ b/celery_progress/static/celery_progress/websockets.js
@@ -48,7 +48,7 @@ var CeleryWebSocketProgressBar = (function () {
                 } else {
                     onTaskError(progressBarElement, progressBarMessageElement, data.result);
                 }
-                if (data.result) {
+                if (data.hasOwnProperty('result')) {
                     onResult(resultElement, data.result);
                 }
                 ProgressSocket.close();

--- a/celery_progress/static/celery_progress/websockets.js
+++ b/celery_progress/static/celery_progress/websockets.js
@@ -7,8 +7,8 @@ var CeleryWebSocketProgressBar = (function () {
         CeleryProgressBar.onResultDefault(resultElement, result);
     }
 
-    function onErrorDefault(progressBarElement, progressBarMessageElement, excMessage) {
-        CeleryProgressBar.onErrorDefault(progressBarElement, progressBarMessageElement, excMessage);
+    function onErrorDefault(progressBarElement, progressBarMessageElement, excMessage, data) {
+        CeleryProgressBar.onErrorDefault(progressBarElement, progressBarMessageElement, excMessage, data);
     }
 
     function onProgressDefault(progressBarElement, progressBarMessageElement, progress) {
@@ -24,6 +24,7 @@ var CeleryWebSocketProgressBar = (function () {
         var onProgress = options.onProgress || onProgressDefault;
         var onSuccess = options.onSuccess || onSuccessDefault;
         var onError = options.onError || onErrorDefault;
+        var onTaskError = options.onTaskError || onError;
         var resultElementId = options.resultElementId || 'celery-result';
         var resultElement = options.resultElement || document.getElementById(resultElementId);
         var onResult = options.onResult || onResultDefault;
@@ -45,7 +46,7 @@ var CeleryWebSocketProgressBar = (function () {
                 if (data.success) {
                     onSuccess(progressBarElement, progressBarMessageElement, data.result);
                 } else {
-                    onError(progressBarElement, progressBarMessageElement, data.result);
+                    onTaskError(progressBarElement, progressBarMessageElement, data.result);
                 }
                 if (data.result) {
                     onResult(resultElement, data.result);


### PR DESCRIPTION
This adds more specific error handlers. As a result:
1. Package users can better customize error handling.
2. The polling client can detect more errors.

`onError` becomes the default generic handlers. Users can customize task errors, network errors, HTTP errors, and data errors. I describe each of them in the README.

I also replaced `if (data.result)` with `if (data.hasOwnProperty('result'))`. The former fails if result is false and assumes there is no result.

I tested these use cases:
1. Network error (offline).
2. Server returns non-200 response (I need this because I wrap celery-progress's view with my own that does authorization).
3. Server returns 200 response with non-JSON data.
4. Server returns 200 response with invalid JSON data (it doesn't have `data.complete` or `data.success`).
5. Successful task.
6. Failed task.
7. Task with result.

3 and 4 are programming errors handled by `onDataError`. There's no good way to handle them except show the user an error and stop polling.

This could address #13.

This is only for the polling client. I do not use webosckets currently, so I can't test websocket specific errors.