### PR TITLE
Make CeleryWebSocketProgressBar a subclass of CeleryProgressBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The `initProgressBar` function takes an optional object of options. The followin
 | onTaskError | function to call when progress completes with an error | onError |
 | onNetworkError | function to call on a network error (ignored by WebSocket) | onError |
 | onHttpError | function to call on a non-200 response (ignored by WebSocket) | onError |
-| onDataError | function to call on a 200 response that's not JSON or has invalid schema due to a programming error (ignored by WebSocket) | onError |
+| onDataError | function to call on a response that's not JSON or has invalid schema due to a programming error | onError |
 | onResult | function to call when returned non empty result | CeleryProgressBar.onResultDefault |
 
 

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -66,24 +66,28 @@ class CeleryProgressBar {
      * @return true if the task is complete, false if it's not, undefined if `data` is invalid
      */
     onData(data) {
+        let done = false;
         if (data.progress) {
             this.onProgress(this.progressBarElement, this.progressBarMessageElement, data.progress);
         }
         if (data.complete === true) {
+            done = true;
             if (data.success === true) {
                 this.onSuccess(this.progressBarElement, this.progressBarMessageElement, this.getMessageDetails(data.result));
             } else if (data.success === false) {
                 this.onTaskError(this.progressBarElement, this.progressBarMessageElement, this.getMessageDetails(data.result));
             } else {
+                done = undefined;
                 this.onDataError(this.progressBarElement, this.progressBarMessageElement, "Data Error");
             }
             if (data.hasOwnProperty('result')) {
                 this.onResult(this.resultElement, data.result);
             }
         } else if (data.complete === undefined) {
+            done = undefined;
             this.onDataError(this.progressBarElement, this.progressBarMessageElement, "Data Error");
         }
-        return data.complete;
+        return done;
     }
 
     async connect() {

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -53,27 +53,27 @@ class CeleryProgressBar {
         }
     }
 
+    getMessageDetails(result) {
+        if (this.resultElement) {
+            return ''
+        } else {
+            return result || '';
+        }
+    }
+
     /**
      * Process update message data.
      * @return true if the task is complete, false if it's not, undefined if `data` is invalid
      */
     onData(data) {
-        const getMessageDetails = function (result) {
-            if (this.resultElement) {
-                return ''
-            } else {
-                return result || '';
-            }
-        };
-
         if (data.progress) {
             this.onProgress(this.progressBarElement, this.progressBarMessageElement, data.progress);
         }
         if (data.complete === true) {
             if (data.success === true) {
-                this.onSuccess(this.progressBarElement, this.progressBarMessageElement, getMessageDetails(data.result));
+                this.onSuccess(this.progressBarElement, this.progressBarMessageElement, this.getMessageDetails(data.result));
             } else if (data.success === false) {
-                this.onTaskError(this.progressBarElement, this.progressBarMessageElement, getMessageDetails(data.result));
+                this.onTaskError(this.progressBarElement, this.progressBarMessageElement, this.getMessageDetails(data.result));
             } else {
                 this.onDataError(this.progressBarElement, this.progressBarMessageElement, "Data Error");
             }

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -23,7 +23,7 @@ class CeleryProgressBar {
 
     static onSuccessDefault(progressBarElement, progressBarMessageElement, result) {
         progressBarElement.style.backgroundColor = '#76ce60';
-        progressBarMessageElement.textContent = "Success!";
+        progressBarMessageElement.textContent = "Success! " + result;
     }
 
     static onResultDefault(resultElement, result) {

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -80,6 +80,8 @@ class CeleryProgressBar {
             if (data.hasOwnProperty('result')) {
                 this.onResult(this.resultElement, data.result);
             }
+        } else if (data.complete === undefined) {
+            this.onDataError(this.progressBarElement, this.progressBarMessageElement, "Data Error");
         }
         return data.complete;
     }

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -1,10 +1,32 @@
-var CeleryProgressBar = (function () {
-    function onSuccessDefault(progressBarElement, progressBarMessageElement, result) {
+class CeleryProgressBar {
+
+    constructor(progressUrl, options) {
+        this.progressUrl = progressUrl;
+        options = options || {};
+        let progressBarId = options.progressBarId || 'progress-bar';
+        let progressBarMessage = options.progressBarMessageId || 'progress-bar-message';
+        this.progressBarElement = options.progressBarElement || document.getElementById(progressBarId);
+        this.progressBarMessageElement = options.progressBarMessageElement || document.getElementById(progressBarMessage);
+        this.onProgress = options.onProgress || CeleryProgressBar.onProgressDefault;
+        this.onSuccess = options.onSuccess || CeleryProgressBar.onSuccessDefault;
+        this.onError = options.onError || CeleryProgressBar.onErrorDefault;
+        this.onTaskError = options.onTaskError || this.onError;
+        this.onDataError = options.onDataError || this.onError;
+        let resultElementId = options.resultElementId || 'celery-result';
+        this.resultElement = options.resultElement || document.getElementById(resultElementId);
+        this.onResult = options.onResult || CeleryProgressBar.onResultDefault;
+        // HTTP options
+        this.onNetworkError = options.onNetworkError || this.onError;
+        this.onHttpError = options.onHttpError || this.onError;
+        this.pollInterval = options.pollInterval || 500;
+    }
+
+    static onSuccessDefault(progressBarElement, progressBarMessageElement, result) {
         progressBarElement.style.backgroundColor = '#76ce60';
         progressBarMessageElement.textContent = "Success!";
     }
 
-    function onResultDefault(resultElement, result) {
+    static onResultDefault(resultElement, result) {
         if (resultElement) {
             resultElement.textContent = result;
         }
@@ -14,13 +36,13 @@ var CeleryProgressBar = (function () {
      * Default handler for all errors.
      * @param data - A Response object for HTTP errors, undefined for other errors
      */
-    function onErrorDefault(progressBarElement, progressBarMessageElement, excMessage, data) {
+    static onErrorDefault(progressBarElement, progressBarMessageElement, excMessage, data) {
         progressBarElement.style.backgroundColor = '#dc4f63';
         excMessage = excMessage || '';
         progressBarMessageElement.textContent = "Uh-Oh, something went wrong! " + excMessage;
     }
 
-    function onProgressDefault(progressBarElement, progressBarMessageElement, progress) {
+    static onProgressDefault(progressBarElement, progressBarMessageElement, progress) {
         progressBarElement.style.backgroundColor = '#68a9ef';
         progressBarElement.style.width = progress.percent + "%";
         var description = progress.description || "";
@@ -35,11 +57,9 @@ var CeleryProgressBar = (function () {
      * Process update message data.
      * @return true if the task is complete, false if it's not, undefined if `data` is invalid
      */
-    function onData(data, onProgress, onSuccess, onTaskError, onDataError, onResult, progressBarElement, progressBarMessageElement, resultElement) {
-        let done = undefined;
-
+    onData(data) {
         const getMessageDetails = function (result) {
-            if (resultElement) {
+            if (this.resultElement) {
                 return ''
             } else {
                 return result || '';
@@ -47,49 +67,29 @@ var CeleryProgressBar = (function () {
         };
 
         if (data.progress) {
-            onProgress(progressBarElement, progressBarMessageElement, data.progress);
+            this.onProgress(this.progressBarElement, this.progressBarMessageElement, data.progress);
         }
-        if (data.complete === false) {
-            done = false;
-        } else {
+        if (data.complete === true) {
             if (data.success === true) {
-                onSuccess(progressBarElement, progressBarMessageElement, getMessageDetails(data.result));
+                this.onSuccess(this.progressBarElement, this.progressBarMessageElement, getMessageDetails(data.result));
             } else if (data.success === false) {
-                onTaskError(progressBarElement, progressBarMessageElement, getMessageDetails(data.result));
+                this.onTaskError(this.progressBarElement, this.progressBarMessageElement, getMessageDetails(data.result));
             } else {
-                onDataError(progressBarElement, progressBarMessageElement, "Data Error");
+                this.onDataError(this.progressBarElement, this.progressBarMessageElement, "Data Error");
             }
             if (data.hasOwnProperty('result')) {
-                onResult(resultElement, data.result);
+                this.onResult(this.resultElement, data.result);
             }
         }
         return data.complete;
     }
 
-    async function updateProgress (progressUrl, options) {
-        options = options || {};
-        var progressBarId = options.progressBarId || 'progress-bar';
-        var progressBarMessage = options.progressBarMessageId || 'progress-bar-message';
-        var progressBarElement = options.progressBarElement || document.getElementById(progressBarId);
-        var progressBarMessageElement = options.progressBarMessageElement || document.getElementById(progressBarMessage);
-        var onProgress = options.onProgress || onProgressDefault;
-        var onSuccess = options.onSuccess || onSuccessDefault;
-        var onError = options.onError || onErrorDefault;
-        var onTaskError = options.onTaskError || onError;
-        var onNetworkError = options.onNetworkError || onError;
-        var onHttpError = options.onHttpError || onError;
-        var onDataError = options.onDataError || onError;
-        var pollInterval = options.pollInterval || 500;
-        var resultElementId = options.resultElementId || 'celery-result';
-        var resultElement = options.resultElement || document.getElementById(resultElementId);
-        var onResult = options.onResult || onResultDefault;
-
-
+    async connect() {
         let response;
         try {
-            response = await fetch(progressUrl);
+            response = await fetch(this.progressUrl);
         } catch (networkError) {
-            onNetworkError(progressBarElement, progressBarMessageElement, "Network Error");
+            this.onNetworkError(this.progressBarElement, this.progressBarMessageElement, "Network Error");
             throw networkError;
         }
 
@@ -98,25 +98,22 @@ var CeleryProgressBar = (function () {
             try {
                 data = await response.json();
             } catch (parsingError) {
-                onDataError(progressBarElement, progressBarMessageElement, "Parsing Error")
+                this.onDataError(this.progressBarElement, this.progressBarMessageElement, "Parsing Error")
                 throw parsingError;
             }
 
-            const done = onData(data, onProgress, onSuccess, onTaskError, onDataError, onResult, progressBarElement, progressBarMessageElement, resultElement);
+            const complete = this.onData(data);
 
-            if (done === false) {
-                setTimeout(updateProgress, pollInterval, progressUrl, options);
+            if (complete === false) {
+                setTimeout(this.connect.bind(this), this.pollInterval);
             }
         } else {
-            onHttpError(progressBarElement, progressBarMessageElement, "HTTP Code " + response.status, response);
+            this.onHttpError(this.progressBarElement, this.progressBarMessageElement, "HTTP Code " + response.status, response);
         }
     }
-    return {
-        onSuccessDefault: onSuccessDefault,
-        onResultDefault: onResultDefault,
-        onErrorDefault: onErrorDefault,
-        onProgressDefault: onProgressDefault,
-        updateProgress: updateProgress,
-        initProgressBar: updateProgress,  // just for api cleanliness
-    };
-})();
+
+    static initProgressBar(progressUrl, options) {
+        const bar = new this(progressUrl, options);
+        bar.connect();
+    }
+}

--- a/celery_progress/static/celery_progress/websockets.js
+++ b/celery_progress/static/celery_progress/websockets.js
@@ -1,67 +1,32 @@
-var CeleryWebSocketProgressBar = (function () {
-    function onSuccessDefault(progressBarElement, progressBarMessageElement, result) {
-        CeleryProgressBar.onSuccessDefault(progressBarElement, progressBarMessageElement);
+class CeleryWebSocketProgressBar extends CeleryProgressBar {
+
+    constructor(progressUrl, options) {
+        super(progressUrl, options);
     }
 
-    function onResultDefault(resultElement, result) {
-        CeleryProgressBar.onResultDefault(resultElement, result);
-    }
-
-    function onErrorDefault(progressBarElement, progressBarMessageElement, excMessage, data) {
-        CeleryProgressBar.onErrorDefault(progressBarElement, progressBarMessageElement, excMessage, data);
-    }
-
-    function onProgressDefault(progressBarElement, progressBarMessageElement, progress) {
-        CeleryProgressBar.onProgressDefault(progressBarElement, progressBarMessageElement, progress);
-    }
-
-    function onData(data, onProgress, onSuccess, onTaskError, onDataError, onResult, progressBarElement, progressBarMessageElement, resultElement) {
-        return CeleryProgressBar.onData(data, onProgress, onSuccess, onTaskError, onDataError, onResult, progressBarElement, progressBarMessageElement, resultElement);
-    }
-
-    function initProgress (progressUrl, options) {
-        options = options || {};
-        var progressBarId = options.progressBarId || 'progress-bar';
-        var progressBarMessage = options.progressBarMessageId || 'progress-bar-message';
-        var progressBarElement = options.progressBarElement || document.getElementById(progressBarId);
-        var progressBarMessageElement = options.progressBarMessageElement || document.getElementById(progressBarMessage);
-        var onProgress = options.onProgress || onProgressDefault;
-        var onSuccess = options.onSuccess || onSuccessDefault;
-        var onError = options.onError || onErrorDefault;
-        var onDataError = options.onDataError || onError;
-        var onTaskError = options.onTaskError || onError;
-        var resultElementId = options.resultElementId || 'celery-result';
-        var resultElement = options.resultElement || document.getElementById(resultElementId);
-        var onResult = options.onResult || onResultDefault;
-
+    async connect() {
         var ProgressSocket = new WebSocket((location.protocol === 'https:' ? 'wss' : 'ws') + '://' +
-            window.location.host + progressUrl);
+            window.location.host + this.progressUrl);
 
         ProgressSocket.onopen = function (event) {
             ProgressSocket.send(JSON.stringify({'type': 'check_task_completion'}));
         };
 
+        const bar = this;
         ProgressSocket.onmessage = function (event) {
             let data;
             try {
                 data = JSON.parse(event.data);
             } catch (parsingError) {
-                onDataError(progressBarElement, progressBarMessageElement, "Parsing Error")
+                bar.onDataError(bar.progressBarElement, bar.progressBarMessageElement, "Parsing Error")
                 throw parsingError;
             }
 
-            const done = onData(data, onProgress, onSuccess, onTaskError, onDataError, onResult, progressBarElement, progressBarMessageElement, resultElement);
+            const complete = bar.onData(data);
 
-            if (done === true || done === undefined) {
+            if (complete === true || complete === undefined) {
                 ProgressSocket.close();
             }
-        }
+        };
     }
-    return {
-        onSuccessDefault: onSuccessDefault,
-        onResultDefault: onResultDefault,
-        onErrorDefault: onErrorDefault,
-        onProgressDefault: onProgressDefault,
-        initProgressBar: initProgress,
-    };
-})();
+}

--- a/celery_progress/static/celery_progress/websockets.js
+++ b/celery_progress/static/celery_progress/websockets.js
@@ -42,7 +42,13 @@ var CeleryWebSocketProgressBar = (function () {
         };
 
         ProgressSocket.onmessage = function (event) {
-            var data = JSON.parse(event.data);
+            let data;
+            try {
+                data = JSON.parse(event.data);
+            } catch (parsingError) {
+                onDataError(progressBarElement, progressBarMessageElement, "Parsing Error")
+                throw parsingError;
+            }
 
             const done = onData(data, onProgress, onSuccess, onTaskError, onDataError, onResult, progressBarElement, progressBarMessageElement, resultElement);
 

--- a/celery_progress/static/celery_progress/websockets.js
+++ b/celery_progress/static/celery_progress/websockets.js
@@ -15,6 +15,10 @@ var CeleryWebSocketProgressBar = (function () {
         CeleryProgressBar.onProgressDefault(progressBarElement, progressBarMessageElement, progress);
     }
 
+    function onData(data, onProgress, onSuccess, onTaskError, onDataError, onResult, progressBarElement, progressBarMessageElement, resultElement) {
+        return CeleryProgressBar.onData(data, onProgress, onSuccess, onTaskError, onDataError, onResult, progressBarElement, progressBarMessageElement, resultElement);
+    }
+
     function initProgress (progressUrl, options) {
         options = options || {};
         var progressBarId = options.progressBarId || 'progress-bar';
@@ -24,6 +28,7 @@ var CeleryWebSocketProgressBar = (function () {
         var onProgress = options.onProgress || onProgressDefault;
         var onSuccess = options.onSuccess || onSuccessDefault;
         var onError = options.onError || onErrorDefault;
+        var onDataError = options.onDataError || onError;
         var onTaskError = options.onTaskError || onError;
         var resultElementId = options.resultElementId || 'celery-result';
         var resultElement = options.resultElement || document.getElementById(resultElementId);
@@ -39,18 +44,9 @@ var CeleryWebSocketProgressBar = (function () {
         ProgressSocket.onmessage = function (event) {
             var data = JSON.parse(event.data);
 
-            if (data.progress) {
-                onProgress(progressBarElement, progressBarMessageElement, data.progress);
-            }
-            if (data.complete) {
-                if (data.success) {
-                    onSuccess(progressBarElement, progressBarMessageElement, data.result);
-                } else {
-                    onTaskError(progressBarElement, progressBarMessageElement, data.result);
-                }
-                if (data.hasOwnProperty('result')) {
-                    onResult(resultElement, data.result);
-                }
+            const done = onData(data, onProgress, onSuccess, onTaskError, onDataError, onResult, progressBarElement, progressBarMessageElement, resultElement);
+
+            if (done === true || done === undefined) {
                 ProgressSocket.close();
             }
         }


### PR DESCRIPTION
closes https://github.com/czue/celery-progress/issues/44

This makes CeleryWebSocketProgressBar a subclass of CeleryProgressBar to reduce inconsistencies.
- Options are passed to the constructor, but the static function `initProgressBar` makes the API backward compatible.
- The code that updates the UI based on `data` lives in a common function `onData`.
- The function `connect` (previously `updateProgress`/`initProgress`) invokes `onData` and contains http/ws specific code.
- The downside of JS classes is that you have to be careful with `this` when passing functions around.

In addition:
- Show result in onSuccessDefault (I don't know if this is intended).
- Catch json parsing error in ws.

I tested using https://github.com/EJH2/cp_ws-example these cases:
- HTTP
- HTTP w/ Error
- HTTP w/ No result element
- HTTP w/ Error + No result element
- HTTP 404
- HTTP Not JSON
- HTTP Invalid JSON
- WS
- WS w/ Error
- WS w/ No result element
- WS w/ Error + No result element