### PR TITLE
Show task started even if it doesn't update progress

### DIFF
--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -42,6 +42,7 @@ class ProgressRecorder(AbstractProgressRecorder):
         self.task.update_state(
             state=PROGRESS_STATE,
             meta={
+                'pending': False,
                 'current': current,
                 'total': total,
                 'percent': percent,
@@ -53,6 +54,7 @@ class ProgressRecorder(AbstractProgressRecorder):
         self.task.update_state(
             state='FAILURE',
             meta={
+                'pending': False,
                 'current': current,
                 'total': total,
                 'percent': 100.0,
@@ -88,22 +90,23 @@ class Progress(object):
             return {
                 'complete': False,
                 'success': None,
-                'progress': _get_unknown_progress(),
+                'progress': _get_unknown_progress(self.result.state),
             }
         return self.result.info
 
 
 def _get_completed_progress():
     return {
+        'pending': False,
         'current': 100,
         'total': 100,
         'percent': 100,
     }
 
 
-def _get_unknown_progress():
+def _get_unknown_progress(state):
     return {
-        'pending': True,
+        'pending': state == 'PENDING',
         'current': 0,
         'total': 100,
         'percent': 0,

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -46,10 +46,14 @@ class CeleryProgressBar {
         progressBarElement.style.backgroundColor = '#68a9ef';
         progressBarElement.style.width = progress.percent + "%";
         var description = progress.description || "";
-        if (progress.current == 0 && progress.pending) {
-          progressBarMessageElement.textContent = 'Waiting for task to start...'
+        if (progress.current == 0) {
+            if (progress.pending === true) {
+                progressBarMessageElement.textContent = 'Waiting for task to start...';
+            } else {
+                progressBarMessageElement.textContent = 'Task started...';
+            }
         } else {
-          progressBarMessageElement.textContent = progress.current + ' of ' + progress.total + ' processed. ' + description;
+            progressBarMessageElement.textContent = progress.current + ' of ' + progress.total + ' processed. ' + description;
         }
     }
 


### PR DESCRIPTION
If a task does not update progress incrementally but has track_started=True, it'll show "Waiting for task to start..." until it finishes. With this it shows "Task started..." instead.