### PR TITLE
Websocket Optimization

### DIFF
--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -24,7 +24,6 @@ class ConsoleProgressRecorder(AbstractProgressRecorder):
     def set_progress(self, current, total, description=""):
         print('processed {} items of {}. {}'.format(current, total, description))
 
-
     def stop_task(self, current, total, exc):
         pass
 
@@ -39,29 +38,33 @@ class ProgressRecorder(AbstractProgressRecorder):
         if total > 0:
             percent = (Decimal(current) / Decimal(total)) * Decimal(100)
             percent = float(round(percent, 2))
+        meta = {
+            'pending': False,
+            'current': current,
+            'total': total,
+            'percent': percent,
+            'description': description
+        }
         self.task.update_state(
             state=PROGRESS_STATE,
-            meta={
-                'pending': False,
-                'current': current,
-                'total': total,
-                'percent': percent,
-                'description': description
-            }
+            meta=meta
         )
+        return meta
 
     def stop_task(self, current, total, exc):
+        meta = {
+            'pending': False,
+            'current': current,
+            'total': total,
+            'percent': 100.0,
+            'exc_message': str(exc),
+            'exc_type': str(type(exc))
+        }
         self.task.update_state(
             state='FAILURE',
-            meta={
-                'pending': False,
-                'current': current,
-                'total': total,
-                'percent': 100.0,
-                'exc_message': str(exc),
-                'exc_type': str(type(exc))
-            }
+            meta=meta
         )
+        return meta
 
 
 class Progress(object):

--- a/celery_progress/websockets/backend.py
+++ b/celery_progress/websockets/backend.py
@@ -1,3 +1,5 @@
+import logging
+
 from celery_progress.backend import ProgressRecorder
 
 try:
@@ -8,15 +10,20 @@ except ImportError:
 else:
     channel_layer = get_channel_layer()
 
-if not channel_layer:
-    RuntimeError(
-        'Tried to use websocket progress bar, but dependencies were not installed / configured. '
-        'Use pip install celery-progress[websockets] and set up channels to enable this feature. '
-        'See: https://channels.readthedocs.io/en/latest/ for more details.'
-    )
+logger = logging.getLogger(__name__)
 
 
 class WebSocketProgressRecorder(ProgressRecorder):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not channel_layer:
+            logger.warning(
+                'Tried to use websocket progress bar, but dependencies were not installed / configured. '
+                'Use pip install celery-progress[websockets] and set up channels to enable this feature. '
+                'See: https://channels.readthedocs.io/en/latest/ for more details.'
+            )
 
     @staticmethod
     def push_update(task_id, data, final=False):

--- a/celery_progress/websockets/backend.py
+++ b/celery_progress/websockets/backend.py
@@ -1,39 +1,32 @@
-import logging
-
 from celery_progress.backend import ProgressRecorder, Progress
 
 try:
     from asgiref.sync import async_to_sync
     from channels.layers import get_channel_layer
 except ImportError:
-    async_to_sync = get_channel_layer = None
-    WEBSOCKETS_AVAILABLE = False
+    channel_layer = None
 else:
-    WEBSOCKETS_AVAILABLE = get_channel_layer()
+    channel_layer = get_channel_layer()
 
-
-logger = logging.getLogger(__name__)
+if not channel_layer:
+    RuntimeError(
+        'Tried to use websocket progress bar, but dependencies were not installed / configured. '
+        'Use pip install celery-progress[websockets] and set up channels to enable this feature. '
+        'See: https://channels.readthedocs.io/en/latest/ for more details.'
+    )
 
 
 class WebSocketProgressRecorder(ProgressRecorder):
 
     @staticmethod
     def push_update(task_id):
-        if WEBSOCKETS_AVAILABLE:
-            try:
-                channel_layer = get_channel_layer()
-                async_to_sync(channel_layer.group_send)(
-                    task_id,
-                    {'type': 'update_task_progress', 'data': {**Progress(task_id).get_info()}}
-                )
-            except AttributeError:  # No channel layer to send to, so ignore it
-                pass
-        else:
-            logger.info(
-                'Tried to use websocket progress bar, but dependencies were not installed / configured. '
-                'Use pip install celery-progress[websockets] and setup channels to enable this feature.'
-                'See: https://channels.readthedocs.io/en/latest/ for more details.'
+        try:
+            async_to_sync(channel_layer.group_send)(
+                task_id,
+                {'type': 'update_task_progress', 'data': {**Progress(task_id).get_info()}}
             )
+        except AttributeError:  # No channel layer to send to, so ignore it
+            pass
 
     def set_progress(self, current, total, description=""):
         super().set_progress(current, total, description)

--- a/celery_progress/websockets/consumers.py
+++ b/celery_progress/websockets/consumers.py
@@ -30,7 +30,7 @@ class ProgressConsumer(AsyncWebsocketConsumer):
                 self.task_id,
                 {
                     'type': 'update_task_progress',
-                    'data': {**Progress(self.task_id).get_info()}
+                    'data': Progress(self.task_id).get_info()
                 }
             )
 

--- a/celery_progress/websockets/tasks.py
+++ b/celery_progress/websockets/tasks.py
@@ -14,4 +14,4 @@ def task_postrun_handler(task_id, **kwargs):
         'progress': {'pending': False, 'current': 100, 'total': 100, 'percent': 100},
         'result': str(kwargs.pop('retval'))
     }
-    WebSocketProgressRecorder.push_update(task_id, data=data)
+    WebSocketProgressRecorder.push_update(task_id, data=data, final=True)

--- a/celery_progress/websockets/tasks.py
+++ b/celery_progress/websockets/tasks.py
@@ -12,6 +12,6 @@ def task_postrun_handler(task_id, **kwargs):
         'complete': True,
         'success': kwargs.pop('state') == 'SUCCESS',
         'progress': {'pending': False, 'current': 100, 'total': 100, 'percent': 100},
-        'result': kwargs.pop('retval')
+        'result': str(kwargs.pop('retval'))
     }
     WebSocketProgressRecorder.push_update(task_id, data=data)

--- a/celery_progress/websockets/tasks.py
+++ b/celery_progress/websockets/tasks.py
@@ -1,6 +1,6 @@
 from celery.signals import task_postrun
 
-from .backend import WEBSOCKETS_AVAILABLE, WebSocketProgressRecorder
+from .backend import channel_layer, WebSocketProgressRecorder
 
 
 @task_postrun.connect
@@ -8,5 +8,5 @@ def task_postrun_handler(task_id, **kwargs):
     """Runs after a task has finished. This will be used to push a websocket update for completed events.
 
     If the websockets version of this package is not installed, this will do nothing."""
-    if WEBSOCKETS_AVAILABLE:
+    if channel_layer:
         WebSocketProgressRecorder.push_update(task_id)


### PR DESCRIPTION
### This pull request includes several changes:
- Importing `WebSocketProgressRecorder` without proper configuration now results in a `RuntimeError`
  - Rather than flooding the console with the same error and providing no indication on the frontend, this aims to alert developers immediately
- The default `ProgressRecorder`'s `set_progress` and `stop_task` functions now return the task metadata
  - This will allow future progress bar implementations to easily extend the functionality of the original, without having to waste a `Progress(task_id).get_info()` to get the same info
- `WebSocketProgressRecorder` now takes advantage of the aforementioned extension
  - This saves having to create an `AsyncResult` instance just to fill a dictionary with basic info

Any reviews would be greatly appreciated.