### PR TITLE
introducing KnownResult for WS

### DIFF
--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -101,7 +101,13 @@ class Progress(object):
                 'success': None,
                 'progress': _get_unknown_progress(self.result.state),
             }
-        return self.result.info
+        else:
+            return {
+                'complete': True,
+                'success': False,
+                'progress': _get_unknown_progress(self.result.state),
+                'result': f'Unknown state [{str(self.result.info)}]',
+            }
 
 
 class KnownResult(EagerResult):

--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -39,6 +39,7 @@ class ProgressRecorder(AbstractProgressRecorder):
         if total > 0:
             percent = (Decimal(current) / Decimal(total)) * Decimal(100)
             percent = float(round(percent, 2))
+        state = PROGRESS_STATE
         meta = {
             'pending': False,
             'current': current,
@@ -47,12 +48,13 @@ class ProgressRecorder(AbstractProgressRecorder):
             'description': description
         }
         self.task.update_state(
-            state=PROGRESS_STATE,
+            state=state,
             meta=meta
         )
-        return meta
+        return state, meta
 
     def stop_task(self, current, total, exc):
+        state = 'FAILURE'
         meta = {
             'pending': False,
             'current': current,
@@ -62,10 +64,10 @@ class ProgressRecorder(AbstractProgressRecorder):
             'exc_type': str(type(exc))
         }
         self.task.update_state(
-            state='FAILURE',
+            state=state,
             meta=meta
         )
-        return meta
+        return state, meta
 
 
 class Progress(object):

--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -73,10 +73,10 @@ class ProgressRecorder(AbstractProgressRecorder):
 class Progress(object):
 
     def __init__(self, result):
-        '''
+        """
         result:
             an AsyncResult or an object that mimics it to a degree
-        '''
+        """
         self.result = result
 
     def get_info(self):
@@ -111,12 +111,12 @@ class Progress(object):
 
 
 class KnownResult(EagerResult):
-    '''Like EagerResult but supports non-ready states.'''
+    """Like EagerResult but supports non-ready states."""
     def __init__(self, id, ret_value, state, traceback=None):
-        '''
+        """
         ret_value:
             result, exception, or progress metadata
-        '''
+        """
         # set backend to get state groups (like READY_STATES in ready())
         self.backend = DisabledBackend
         super().__init__(id, ret_value, state, traceback)

--- a/celery_progress/views.py
+++ b/celery_progress/views.py
@@ -1,8 +1,9 @@
 import json
 from django.http import HttpResponse
+from celery.result import AsyncResult
 from celery_progress.backend import Progress
 
 
 def get_progress(request, task_id):
-    progress = Progress(task_id)
+    progress = Progress(AsyncResult(task_id))
     return HttpResponse(json.dumps(progress.get_info()), content_type='application/json')

--- a/celery_progress/websockets/backend.py
+++ b/celery_progress/websockets/backend.py
@@ -1,5 +1,6 @@
 import logging
 
+from celery.result import AsyncResult
 from celery_progress.backend import ProgressRecorder, Progress
 
 try:
@@ -24,7 +25,7 @@ class WebSocketProgressRecorder(ProgressRecorder):
                 channel_layer = get_channel_layer()
                 async_to_sync(channel_layer.group_send)(
                     task_id,
-                    {'type': 'update_task_progress', 'data': {**Progress(task_id).get_info()}}
+                    {'type': 'update_task_progress', 'data': {**Progress(AsyncResult(task_id)).get_info()}}
                 )
             except AttributeError:  # No channel layer to send to, so ignore it
                 pass

--- a/celery_progress/websockets/consumers.py
+++ b/celery_progress/websockets/consumers.py
@@ -1,6 +1,7 @@
 from channels.generic.websocket import AsyncWebsocketConsumer
 import json
 
+from celery.result import AsyncResult
 from celery_progress.backend import Progress
 
 
@@ -30,7 +31,7 @@ class ProgressConsumer(AsyncWebsocketConsumer):
                 self.task_id,
                 {
                     'type': 'update_task_progress',
-                    'data': {**Progress(self.task_id).get_info()}
+                    'data': {**Progress(AsyncResult(self.task_id)).get_info()}
                 }
             )
 

--- a/celery_progress/websockets/consumers.py
+++ b/celery_progress/websockets/consumers.py
@@ -31,7 +31,7 @@ class ProgressConsumer(AsyncWebsocketConsumer):
                 self.task_id,
                 {
                     'type': 'update_task_progress',
-                    'data': Progress(self.task_id).get_info()
+                    'data': Progress(AsyncResult(self.task_id)).get_info()
                 }
             )
 

--- a/celery_progress/websockets/tasks.py
+++ b/celery_progress/websockets/tasks.py
@@ -1,6 +1,7 @@
 from celery.signals import task_postrun
 
 from .backend import WebSocketProgressRecorder
+from celery_progress.backend import KnownResult, Progress
 
 
 @task_postrun.connect(retry=True)
@@ -8,10 +9,6 @@ def task_postrun_handler(task_id, **kwargs):
     """Runs after a task has finished. This will be used to push a websocket update for completed events.
 
     If the websockets version of this package is not installed, this will fail silently."""
-    data = {
-        'complete': True,
-        'success': kwargs.pop('state') == 'SUCCESS',
-        'progress': {'pending': False, 'current': 100, 'total': 100, 'percent': 100},
-        'result': str(kwargs.pop('retval'))
-    }
+    result = KnownResult(task_id, kwargs.pop('retval'), kwargs.pop('state'))
+    data = Progress(result).get_info()
     WebSocketProgressRecorder.push_update(task_id, data=data, final=True)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='celery-progress',
-    version='0.0.11',
+    version='0.0.12',
     packages=find_packages(),
     include_package_data=True,
     license='MIT License',


### PR DESCRIPTION
Following from https://github.com/czue/celery-progress/pull/51.

This is one way for the WS backend to avoid `AsyncResult` but still use `Progress.get_info`.

`Progress.get_info` can take either an `AsyncResult` or a `KnownResult`. WS code would use a `KnownResult`.

If this is ok, it should be tested with #51 before merging.