### PR TITLE
switch from f-string to string format

### DIFF
--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -106,7 +106,7 @@ class Progress(object):
                 'complete': True,
                 'success': False,
                 'progress': _get_unknown_progress(self.result.state),
-                'result': f'Unknown state [{str(self.result.info)}]',
+                'result': 'Unknown state {}'.format(str(self.result.info)),
             }
 
 


### PR DESCRIPTION
I sadly have a python 3.5 project using this lib and this breaks it.

I think it's likely fine to introduce f-strings and require 3.6+ but maybe we can do that in the next release?

I also created this issue so that it's clearer what the expectations are: https://github.com/czue/celery-progress/issues/56