### PR TITLE
Remove stop_task

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,6 @@ You can add an optional progress description like this:
   progress_recorder.set_progress(i + 1, seconds, description='my progress description')
 ```
 
-You can stop your task with an exception message like this:
-
-```python
-  progress_recorder.stop_task(i + 1, seconds, 'my exception message')
-```
-
 ### Displaying progress
 
 In the view where you call the task you need to get the task ID like so:
@@ -175,8 +169,8 @@ The `initProgressBar` function takes an optional object of options. The followin
 
 # WebSocket Support
 
-This library has experimental WebSocket support using [Django Channels](https://channels.readthedocs.io/en/latest/)
-courtesy of [@EJH2](https://github.com/EJH2/).
+Additionally, this library has offers WebSocket support using [Django Channels](https://channels.readthedocs.io/en/latest/)
+courtesy of [EJH2](https://github.com/EJH2/).
 
 A working example project leveraging WebSockets is [available here](https://github.com/EJH2/cp_ws-example).
 

--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -15,18 +15,11 @@ class AbstractProgressRecorder(object):
     def set_progress(self, current, total, description=""):
         pass
 
-    @abstractmethod
-    def stop_task(self, current, total, exc):
-        pass
-
 
 class ConsoleProgressRecorder(AbstractProgressRecorder):
 
     def set_progress(self, current, total, description=""):
         print('processed {} items of {}. {}'.format(current, total, description))
-
-    def stop_task(self, current, total, exc):
-        pass
 
 
 class ProgressRecorder(AbstractProgressRecorder):
@@ -46,22 +39,6 @@ class ProgressRecorder(AbstractProgressRecorder):
             'total': total,
             'percent': percent,
             'description': description
-        }
-        self.task.update_state(
-            state=state,
-            meta=meta
-        )
-        return state, meta
-
-    def stop_task(self, current, total, exc):
-        state = 'FAILURE'
-        meta = {
-            'pending': False,
-            'current': current,
-            'total': total,
-            'percent': 100.0,
-            'exc_message': str(exc),
-            'exc_type': str(type(exc))
         }
         self.task.update_state(
             state=state,

--- a/celery_progress/websockets/backend.py
+++ b/celery_progress/websockets/backend.py
@@ -43,9 +43,3 @@ class WebSocketProgressRecorder(ProgressRecorder):
         result = KnownResult(self.task.request.id, meta, state)
         data = Progress(result).get_info()
         self.push_update(self.task.request.id, data)
-
-    def stop_task(self, current, total, exc):
-        state, _ = super().stop_task(current, total, exc)
-        result = KnownResult(self.task.request.id, exc, state)
-        data = Progress(result).get_info()
-        self.push_update(self.task.request.id, data)


### PR DESCRIPTION
Resolves #59

This removes the ProgressRecorder.stop_task function, as we believe it does not fit with the core values of the package.