### PR TITLE
Support Retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The `initProgressBar` function takes an optional object of options. The followin
 | onProgress | function to call when progress is updated | CeleryProgressBar.onProgressDefault |
 | onSuccess | function to call when progress successfully completes | CeleryProgressBar.onSuccessDefault |
 | onError | function to call on a known error with no specified handler | CeleryProgressBar.onErrorDefault |
+| onRetry | function to call when task a task attempts to retry | CeleryProgressBar.onRetryDefault |
 | onTaskError | function to call when progress completes with an error | onError |
 | onNetworkError | function to call on a network error (ignored by WebSocket) | onError |
 | onHttpError | function to call on a non-200 response (ignored by WebSocket) | onError |

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The `initProgressBar` function takes an optional object of options. The followin
 | onProgress | function to call when progress is updated | CeleryProgressBar.onProgressDefault |
 | onSuccess | function to call when progress successfully completes | CeleryProgressBar.onSuccessDefault |
 | onError | function to call on a known error with no specified handler | CeleryProgressBar.onErrorDefault |
-| onRetry | function to call when task a task attempts to retry | CeleryProgressBar.onRetryDefault |
+| onRetry | function to call when a task attempts to retry | CeleryProgressBar.onRetryDefault |
 | onTaskError | function to call when progress completes with an error | onError |
 | onNetworkError | function to call on a network error (ignored by WebSocket) | onError |
 | onHttpError | function to call on a non-200 response (ignored by WebSocket) | onError |

--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -58,20 +58,21 @@ class Progress(object):
         self.result = result
 
     def get_info(self):
+        response = {'state': self.result.state}
         if self.result.ready():
             success = self.result.successful()
             with allow_join_result():
-                return {
+                response.update({
                     'complete': True,
                     'success': success,
                     'progress': _get_completed_progress(),
                     'result': self.result.get(self.result.id) if success else str(self.result.info),
-                }
+                })
         elif self.result.state == 'RETRY':
             retry = self.result.info
             when = str(retry.when) if isinstance(retry.when, datetime.datetime) else str(
                     datetime.datetime.now() + datetime.timedelta(seconds=retry.when))
-            return {
+            response.update({
                 'complete': True,
                 'success': False,
                 'progress': _get_completed_progress(),
@@ -79,27 +80,27 @@ class Progress(object):
                     'when': when,
                     'message': retry.message or str(retry.exc)
                 },
-                'retry': True
-            }
+            })
         elif self.result.state == PROGRESS_STATE:
-            return {
+            response.update({
                 'complete': False,
                 'success': None,
                 'progress': self.result.info,
-            }
+            })
         elif self.result.state in ['PENDING', 'STARTED']:
-            return {
+            response.update({
                 'complete': False,
                 'success': None,
                 'progress': _get_unknown_progress(self.result.state),
-            }
+            })
         else:
-            return {
+            response.update({
                 'complete': True,
                 'success': False,
                 'progress': _get_unknown_progress(self.result.state),
                 'result': 'Unknown state {}'.format(str(self.result.info)),
-            }
+            })
+        return response
 
 
 class KnownResult(EagerResult):

--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -1,3 +1,4 @@
+import datetime
 from abc import ABCMeta, abstractmethod
 from decimal import Decimal
 
@@ -66,6 +67,20 @@ class Progress(object):
                     'progress': _get_completed_progress(),
                     'result': self.result.get(self.result.id) if success else str(self.result.info),
                 }
+        elif self.result.state == 'RETRY':
+            retry = self.result.info
+            when = str(retry.when) if isinstance(retry.when, datetime.datetime) else str(
+                    datetime.datetime.now() + datetime.timedelta(seconds=retry.when))
+            return {
+                'complete': True,
+                'success': False,
+                'progress': _get_completed_progress(),
+                'result': {
+                    'when': when,
+                    'message': retry.message or str(retry.exc)
+                },
+                'retry': True
+            }
         elif self.result.state == PROGRESS_STATE:
             return {
                 'complete': False,

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -12,6 +12,7 @@ class CeleryProgressBar {
         this.onError = options.onError || CeleryProgressBar.onErrorDefault;
         this.onTaskError = options.onTaskError || this.onError;
         this.onDataError = options.onDataError || this.onError;
+        this.onRetry = options.onRetry || this.onRetryDefault;
         let resultElementId = options.resultElementId || 'celery-result';
         this.resultElement = options.resultElement || document.getElementById(resultElementId);
         this.onResult = options.onResult || CeleryProgressBar.onResultDefault;
@@ -40,6 +41,12 @@ class CeleryProgressBar {
         progressBarElement.style.backgroundColor = '#dc4f63';
         excMessage = excMessage || '';
         progressBarMessageElement.textContent = "Uh-Oh, something went wrong! " + excMessage;
+    }
+
+    onRetryDefault(progressBarElement, progressBarMessageElement, excMessage, retryWhen) {
+        retryWhen = new Date(retryWhen);
+        let message = 'Retrying in ' + Math.round((retryWhen.getTime() - Date.now())/1000) + 's: ' + excMessage;
+        this.onTaskError(progressBarElement, progressBarMessageElement, message);
     }
 
     static onProgressDefault(progressBarElement, progressBarMessageElement, progress) {

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -86,7 +86,13 @@ class CeleryProgressBar {
             if (data.success === true) {
                 this.onSuccess(this.progressBarElement, this.progressBarMessageElement, this.getMessageDetails(data.result));
             } else if (data.success === false) {
-                this.onTaskError(this.progressBarElement, this.progressBarMessageElement, this.getMessageDetails(data.result));
+                if (data.hasOwnProperty('retry')) {
+                    this.onRetry(this.progressBarElement, this.progressBarMessageElement, data.result.message, data.result.when);
+                    done = false;
+                    delete data.result;
+                } else {
+                    this.onTaskError(this.progressBarElement, this.progressBarMessageElement, this.getMessageDetails(data.result));
+                }
             } else {
                 done = undefined;
                 this.onDataError(this.progressBarElement, this.progressBarMessageElement, "Data Error");

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -86,7 +86,7 @@ class CeleryProgressBar {
             if (data.success === true) {
                 this.onSuccess(this.progressBarElement, this.progressBarMessageElement, this.getMessageDetails(data.result));
             } else if (data.success === false) {
-                if (data.hasOwnProperty('retry')) {
+                if (data.state === 'RETRY') {
                     this.onRetry(this.progressBarElement, this.progressBarMessageElement, data.result.message, data.result.when);
                     done = false;
                     delete data.result;


### PR DESCRIPTION
This PR adds support for retries as noted in #54.

- Retries will now fill the bar with red with a notice for how long until the next retry, and then the bar will start over with next progress update
- Created custom retry handling method in JS to allow users to extend current behavior