### PR TITLE
Custom Colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The `initProgressBar` function takes an optional object of options. The followin
 | onHttpError | function to call on a non-200 response (ignored by WebSocket) | onError |
 | onDataError | function to call on a response that's not JSON or has invalid schema due to a programming error | onError |
 | onResult | function to call when returned non empty result | CeleryProgressBar.onResultDefault |
-
+| barColors | dictionary containing color values for various progress bar states. Colors that are not specified will defer to defaults | {'success': '#76ce60', 'error': '#dc4f63', 'progress': '#68a9ef'} |
 
 # WebSocket Support
 

--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ The `initProgressBar` function takes an optional object of options. The followin
 | progressBarMessageElement | Override the *element* used for the progress bar message. If specified, progressBarMessageId will be ignored. | document.getElementById(progressBarMessageId) |
 | resultElementId | Override the ID used for the result | 'celery-result' |
 | resultElement | Override the *element* used for the result. If specified, resultElementId will be ignored. | document.getElementById(resultElementId) |
-| onProgress | function to call when progress is updated | CeleryProgressBar.onProgressDefault |
-| onSuccess | function to call when progress successfully completes | CeleryProgressBar.onSuccessDefault |
-| onError | function to call on a known error with no specified handler | CeleryProgressBar.onErrorDefault |
-| onRetry | function to call when a task attempts to retry | CeleryProgressBar.onRetryDefault |
+| onProgress | function to call when progress is updated | onProgressDefault |
+| onSuccess | function to call when progress successfully completes | onSuccessDefault |
+| onError | function to call on a known error with no specified handler | onErrorDefault |
+| onRetry | function to call when a task attempts to retry | onRetryDefault |
 | onTaskError | function to call when progress completes with an error | onError |
 | onNetworkError | function to call on a network error (ignored by WebSocket) | onError |
 | onHttpError | function to call on a non-200 response (ignored by WebSocket) | onError |

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -7,9 +7,9 @@ class CeleryProgressBar {
         let progressBarMessage = options.progressBarMessageId || 'progress-bar-message';
         this.progressBarElement = options.progressBarElement || document.getElementById(progressBarId);
         this.progressBarMessageElement = options.progressBarMessageElement || document.getElementById(progressBarMessage);
-        this.onProgress = options.onProgress || CeleryProgressBar.onProgressDefault;
-        this.onSuccess = options.onSuccess || CeleryProgressBar.onSuccessDefault;
-        this.onError = options.onError || CeleryProgressBar.onErrorDefault;
+        this.onProgress = options.onProgress || this.onProgressDefault;
+        this.onSuccess = options.onSuccess || this.onSuccessDefault;
+        this.onError = options.onError || this.onErrorDefault;
         this.onTaskError = options.onTaskError || this.onError;
         this.onDataError = options.onDataError || this.onError;
         this.onRetry = options.onRetry || this.onRetryDefault;
@@ -29,8 +29,8 @@ class CeleryProgressBar {
         this.barColors = Object.assign({}, barColors, options.barColors);
     }
 
-    static onSuccessDefault(progressBarElement, progressBarMessageElement, result) {
-        progressBarElement.style.backgroundColor = '#76ce60';
+    onSuccessDefault(progressBarElement, progressBarMessageElement, result) {
+        progressBarElement.style.backgroundColor = this.barColors.success;
         progressBarMessageElement.textContent = "Success! " + result;
     }
 
@@ -44,8 +44,8 @@ class CeleryProgressBar {
      * Default handler for all errors.
      * @param data - A Response object for HTTP errors, undefined for other errors
      */
-    static onErrorDefault(progressBarElement, progressBarMessageElement, excMessage, data) {
-        progressBarElement.style.backgroundColor = '#dc4f63';
+    onErrorDefault(progressBarElement, progressBarMessageElement, excMessage, data) {
+        progressBarElement.style.backgroundColor = this.barColors.error;
         excMessage = excMessage || '';
         progressBarMessageElement.textContent = "Uh-Oh, something went wrong! " + excMessage;
     }
@@ -56,8 +56,8 @@ class CeleryProgressBar {
         this.onTaskError(progressBarElement, progressBarMessageElement, message);
     }
 
-    static onProgressDefault(progressBarElement, progressBarMessageElement, progress) {
-        progressBarElement.style.backgroundColor = '#68a9ef';
+    onProgressDefault(progressBarElement, progressBarMessageElement, progress) {
+        progressBarElement.style.backgroundColor = this.barColors.progress;
         progressBarElement.style.width = progress.percent + "%";
         var description = progress.description || "";
         if (progress.current == 0) {

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -20,6 +20,13 @@ class CeleryProgressBar {
         this.onNetworkError = options.onNetworkError || this.onError;
         this.onHttpError = options.onHttpError || this.onError;
         this.pollInterval = options.pollInterval || 500;
+        // Other options
+        let barColors = {
+            'success': '#76ce60',
+            'error': '#dc4f63',
+            'progress': '#68a9ef'
+        }
+        this.barColors = Object.assign({}, barColors, options.barColors);
     }
 
     static onSuccessDefault(progressBarElement, progressBarMessageElement, result) {


### PR DESCRIPTION
Resolves #5

This PR aims to add the ability to change progress bar colors in a (noob-)friendly fashion (basically not having to override the whole function just to change one line). Usage would look as follows:
```js
CeleryProgressBar.initProgressBar(taskURL, {barColors: {'progress': '#ef4'}})
```
The above example would change the progress bar color to yellow. Any colors that aren't expressly overridden will defer to the default value, as specified in the documentation. This would also allow us to add new colors (such as IGNORED) without necessarily needing to break everything if people are only overriding for color changes.