### PR TITLE
Support Revoked State

### DIFF
--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 from celery.result import EagerResult, allow_join_result
 from celery.backends.base import DisabledBackend
+from celery import states
 
 
 PROGRESS_STATE = 'PROGRESS'
@@ -59,7 +60,7 @@ class Progress(object):
 
     def get_info(self):
         response = {'state': self.result.state}
-        if self.result.ready():
+        if self.result.state in [states.SUCCESS, states.FAILURE]:
             success = self.result.successful()
             with allow_join_result():
                 response.update({
@@ -87,7 +88,7 @@ class Progress(object):
                 'success': None,
                 'progress': self.result.info,
             })
-        elif self.result.state in ['PENDING', 'STARTED']:
+        elif self.result.state in states.UNREADY_STATES:
             response.update({
                 'complete': False,
                 'success': None,

--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 
 from celery.result import EagerResult, allow_join_result
 from celery.backends.base import DisabledBackend
-from celery import states
 
 
 PROGRESS_STATE = 'PROGRESS'
@@ -60,7 +59,7 @@ class Progress(object):
 
     def get_info(self):
         response = {'state': self.result.state}
-        if self.result.state in [states.SUCCESS, states.FAILURE]:
+        if self.result.state in ['SUCCESS', 'FAILURE']:
             success = self.result.successful()
             with allow_join_result():
                 response.update({
@@ -69,7 +68,7 @@ class Progress(object):
                     'progress': _get_completed_progress(),
                     'result': self.result.get(self.result.id) if success else str(self.result.info),
                 })
-        elif self.result.state in states.EXCEPTION_STATES:
+        elif self.result.state in ['RETRY', 'REVOKED']:
             if self.result.state == 'RETRY':
                 retry = self.result.info
                 when = str(retry.when) if isinstance(retry.when, datetime.datetime) else str(
@@ -89,7 +88,7 @@ class Progress(object):
                 'success': None,
                 'progress': self.result.info,
             })
-        elif self.result.state in states.UNREADY_STATES:
+        elif self.result.state in ['PENDING', 'STARTED']:
             response.update({
                 'complete': False,
                 'success': None,

--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -69,18 +69,19 @@ class Progress(object):
                     'progress': _get_completed_progress(),
                     'result': self.result.get(self.result.id) if success else str(self.result.info),
                 })
-        elif self.result.state == 'RETRY':
-            retry = self.result.info
-            when = str(retry.when) if isinstance(retry.when, datetime.datetime) else str(
-                    datetime.datetime.now() + datetime.timedelta(seconds=retry.when))
+        elif self.result.state in states.EXCEPTION_STATES:
+            if self.result.state == 'RETRY':
+                retry = self.result.info
+                when = str(retry.when) if isinstance(retry.when, datetime.datetime) else str(
+                        datetime.datetime.now() + datetime.timedelta(seconds=retry.when))
+                result = {'when': when, 'message': retry.message or str(retry.exc)}
+            else:
+                result = 'Task ' + str(self.result.info)
             response.update({
                 'complete': True,
                 'success': False,
                 'progress': _get_completed_progress(),
-                'result': {
-                    'when': when,
-                    'message': retry.message or str(retry.exc)
-                },
+                'result': result,
             })
         elif self.result.state == PROGRESS_STATE:
             response.update({

--- a/celery_progress/websockets/tasks.py
+++ b/celery_progress/websockets/tasks.py
@@ -1,4 +1,4 @@
-from celery.signals import task_postrun
+from celery.signals import task_postrun, task_revoked
 
 from .backend import WebSocketProgressRecorder
 from celery_progress.backend import KnownResult, Progress
@@ -12,3 +12,15 @@ def task_postrun_handler(task_id, **kwargs):
     result = KnownResult(task_id, kwargs.pop('retval'), kwargs.pop('state'))
     data = Progress(result).get_info()
     WebSocketProgressRecorder.push_update(task_id, data=data, final=True)
+
+
+@task_revoked.connect(retry=True)
+def task_revoked_handler(request, **kwargs):
+    """Runs if a task has been revoked. This will be used to push a websocket update for revoked events.
+
+    If the websockets version of this package is not installed, this will fail silently."""
+    _result = ('terminated' if kwargs.pop('terminated') else None) or ('expired' if kwargs.pop('expired') else None) \
+        or 'revoked'
+    result = KnownResult(request.id, _result, 'REVOKED')
+    data = Progress(result).get_info()
+    WebSocketProgressRecorder.push_update(request.id, data=data, final=True)


### PR DESCRIPTION
This PR adds (more) support for the REVOKED task state as discussed in #54. Notable changes in this PR include:
- Added `task_revoked_handler` in websockets/tasks.py to handle revoked/terminated/expired tasks.
- `Progress.get_info()` now uses `celery.states` for state comparisons. This should make the comparisons a tad clearer on what they actually are.
- "Ready" tasks no longer use `self.result.ready()`, as that was intercepting REVOKED task states and not allowing us to pretty up the output before shipping to the frontend.

Sample outputs can be seen below:
![image](https://user-images.githubusercontent.com/14126443/97249159-acd64e00-17d9-11eb-9f1c-0bd0d7a69d57.png)
![image](https://user-images.githubusercontent.com/14126443/97249173-b6f84c80-17d9-11eb-8861-a839477e8b57.png)
![image](https://user-images.githubusercontent.com/14126443/97249202-c1b2e180-17d9-11eb-8bd0-3a7cf927b060.png)
