### PR TITLE
Support Ignored State

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The `initProgressBar` function takes an optional object of options. The followin
 | onSuccess | function to call when progress successfully completes | onSuccessDefault |
 | onError | function to call on a known error with no specified handler | onErrorDefault |
 | onRetry | function to call when a task attempts to retry | onRetryDefault |
+| onIgnored | function to call when a task result is ignored | onIgnoredDefault |
 | onTaskError | function to call when progress completes with an error | onError |
 | onNetworkError | function to call on a network error (ignored by WebSocket) | onError |
 | onHttpError | function to call on a non-200 response (ignored by WebSocket) | onError |

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The `initProgressBar` function takes an optional object of options. The followin
 | onHttpError | function to call on a non-200 response (ignored by WebSocket) | onError |
 | onDataError | function to call on a response that's not JSON or has invalid schema due to a programming error | onError |
 | onResult | function to call when returned non empty result | CeleryProgressBar.onResultDefault |
-| barColors | dictionary containing color values for various progress bar states. Colors that are not specified will defer to defaults | {'success': '#76ce60', 'error': '#dc4f63', 'progress': '#68a9ef'} |
+| barColors | dictionary containing color values for various progress bar states. Colors that are not specified will defer to defaults | barColorsDefault |
 
 # WebSocket Support
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The `barColors` option allows you to customize the color of each progress bar st
 
 # WebSocket Support
 
-Additionally, this library has offers WebSocket support using [Django Channels](https://channels.readthedocs.io/en/latest/)
+Additionally, this library offers WebSocket support using [Django Channels](https://channels.readthedocs.io/en/latest/)
 courtesy of [EJH2](https://github.com/EJH2/).
 
 A working example project leveraging WebSockets is [available here](https://github.com/EJH2/cp_ws-example).

--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ The `initProgressBar` function takes an optional object of options. The followin
 | onResult | function to call when returned non empty result | CeleryProgressBar.onResultDefault |
 | barColors | dictionary containing color values for various progress bar states. Colors that are not specified will defer to defaults | barColorsDefault |
 
+The `barColors` option allows you to customize the color of each progress bar state by passing a dictionary of key-value pairs of `state: #hexcode`. The defaults are shown below.
+
+| State | Hex Code | Image Color | 
+|-------|----------|:-------------:|
+| success | #76ce60 | ![#76ce60](https://placehold.it/15/76ce60/000000?text=+) |
+| error | #dc4f63 | ![#dc4f63](https://placehold.it/15/dc4f63/000000?text=+) |
+| progress | #68a9ef | ![#68a9ef](https://placehold.it/15/68a9ef/000000?text=+) |
+| ignored | #7a7a7a | ![#7a7a7a](https://placehold.it/15/7a7a7a/000000?text=+) |
+
 # WebSocket Support
 
 Additionally, this library has offers WebSocket support using [Django Channels](https://channels.readthedocs.io/en/latest/)

--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -82,6 +82,12 @@ class Progress(object):
                 'progress': _get_completed_progress(),
                 'result': result,
             })
+        elif self.result.state == 'IGNORED':
+            response.update({
+                'complete': True,
+                'success': None,
+                'progress': _get_completed_progress()
+            })
         elif self.result.state == PROGRESS_STATE:
             response.update({
                 'complete': False,

--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -86,7 +86,8 @@ class Progress(object):
             response.update({
                 'complete': True,
                 'success': None,
-                'progress': _get_completed_progress()
+                'progress': _get_completed_progress(),
+                'result': str(self.result.info)
             })
         elif self.result.state == PROGRESS_STATE:
             response.update({

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -22,13 +22,13 @@ class CeleryProgressBar {
         this.onHttpError = options.onHttpError || this.onError;
         this.pollInterval = options.pollInterval || 500;
         // Other options
-        let barColors = {
+        let barColorsDefault = {
             'success': '#76ce60',
             'error': '#dc4f63',
             'progress': '#68a9ef',
             'ignored': '#7a7a7a'
         }
-        this.barColors = Object.assign({}, barColors, options.barColors);
+        this.barColors = Object.assign({}, barColorsDefault, options.barColors);
     }
 
     onSuccessDefault(progressBarElement, progressBarMessageElement, result) {

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -108,8 +108,12 @@ class CeleryProgressBar {
                     this.onTaskError(this.progressBarElement, this.progressBarMessageElement, this.getMessageDetails(data.result));
                 }
             } else {
-                done = undefined;
-                this.onDataError(this.progressBarElement, this.progressBarMessageElement, "Data Error");
+                if (data.state === 'IGNORED') {
+                    this.onIgnored(this.progressBarElement, this.progressBarMessageElement);
+                } else {
+                    done = undefined;
+                    this.onDataError(this.progressBarElement, this.progressBarMessageElement, "Data Error");
+                }
             }
             if (data.hasOwnProperty('result')) {
                 this.onResult(this.resultElement, data.result);

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -23,10 +23,10 @@ class CeleryProgressBar {
         this.pollInterval = options.pollInterval || 500;
         // Other options
         let barColorsDefault = {
-            'success': '#76ce60',
-            'error': '#dc4f63',
-            'progress': '#68a9ef',
-            'ignored': '#7a7a7a'
+            success: '#76ce60',
+            error: '#dc4f63',
+            progress: '#68a9ef',
+            ignored: '#7a7a7a'
         }
         this.barColors = Object.assign({}, barColorsDefault, options.barColors);
     }

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -58,9 +58,9 @@ class CeleryProgressBar {
         this.onTaskError(progressBarElement, progressBarMessageElement, message);
     }
 
-    onIgnoredDefault(progressBarElement, progressBarMessageElement) {
+    onIgnoredDefault(progressBarElement, progressBarMessageElement, result) {
         progressBarElement.style.backgroundColor = this.barColors.ignored;
-        progressBarMessageElement.textContent = 'Task result ignored!'
+        progressBarMessageElement.textContent =  result || 'Task result ignored!'
     }
 
     onProgressDefault(progressBarElement, progressBarMessageElement, progress) {
@@ -109,7 +109,8 @@ class CeleryProgressBar {
                 }
             } else {
                 if (data.state === 'IGNORED') {
-                    this.onIgnored(this.progressBarElement, this.progressBarMessageElement);
+                    this.onIgnored(this.progressBarElement, this.progressBarMessageElement, data.result);
+                    delete data.result;
                 } else {
                     done = undefined;
                     this.onDataError(this.progressBarElement, this.progressBarMessageElement, "Data Error");

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -13,6 +13,7 @@ class CeleryProgressBar {
         this.onTaskError = options.onTaskError || this.onError;
         this.onDataError = options.onDataError || this.onError;
         this.onRetry = options.onRetry || this.onRetryDefault;
+        this.onIgnored = options.onIgnored || this.onIgnoredDefault;
         let resultElementId = options.resultElementId || 'celery-result';
         this.resultElement = options.resultElement || document.getElementById(resultElementId);
         this.onResult = options.onResult || CeleryProgressBar.onResultDefault;
@@ -24,7 +25,8 @@ class CeleryProgressBar {
         let barColors = {
             'success': '#76ce60',
             'error': '#dc4f63',
-            'progress': '#68a9ef'
+            'progress': '#68a9ef',
+            'ignored': '#7a7a7a'
         }
         this.barColors = Object.assign({}, barColors, options.barColors);
     }
@@ -54,6 +56,11 @@ class CeleryProgressBar {
         retryWhen = new Date(retryWhen);
         let message = 'Retrying in ' + Math.round((retryWhen.getTime() - Date.now())/1000) + 's: ' + excMessage;
         this.onTaskError(progressBarElement, progressBarMessageElement, message);
+    }
+
+    onIgnoredDefault(progressBarElement, progressBarMessageElement) {
+        progressBarElement.style.backgroundColor = this.barColors.ignored;
+        progressBarMessageElement.textContent = 'Task result ignored!'
     }
 
     onProgressDefault(progressBarElement, progressBarMessageElement, progress) {

--- a/celery_progress/tasks.py
+++ b/celery_progress/tasks.py
@@ -1,0 +1,11 @@
+from celery.signals import task_postrun
+
+
+@task_postrun.connect(retry=True)
+def task_postrun_handler(**kwargs):
+    """Runs after a task has finished. This will update the result backend to include the IGNORED result state.
+
+    Necessary for HTTP to properly receive ignored task event."""
+    if kwargs.pop('state') == 'IGNORED':
+        task = kwargs.pop('task')
+        task.update_state(state='IGNORED')

--- a/celery_progress/tasks.py
+++ b/celery_progress/tasks.py
@@ -8,4 +8,4 @@ def task_postrun_handler(**kwargs):
     Necessary for HTTP to properly receive ignored task event."""
     if kwargs.pop('state') == 'IGNORED':
         task = kwargs.pop('task')
-        task.update_state(state='IGNORED')
+        task.update_state(state='IGNORED', meta=str(kwargs.pop('retval')))


### PR DESCRIPTION
Part 3 of 4 in the saga that is #54. Significant changes in this PR:

- Added `IGNORED` state support to Progress.get_info().
- Added `onIgnored` funtion to JS (as well as the associated color).
    - Default configuration looks like so: 
![image](https://user-images.githubusercontent.com/14126443/97395473-6d802e00-18bb-11eb-88de-b3bb9b8bb557.png) 
If a user specifies an error message (i.e. doing `raise Ignore('lol')`), it will use the error message instead like so: 
![image](https://user-images.githubusercontent.com/14126443/97396726-07e17100-18be-11eb-839b-ba921c09fa7f.png)
- Added a cleaner and clearer default settings visualization for `barColors`, taking the form of a table.
- Added a post-run handler to the base package to make sure that the HTTP progress bars properly receive the ignored event.
    - This is an unfortunate but necessary change, as without the post-run handler updating the backend, the backend will only show the last progress update it received. This is obviously less than ideal since the intent is to disconnect the task.

All that's left from the aforementioned issue is to investigate the behavior of `store_errors_even_if_ignored`, although I believe Omar was going to take a crack at that. Suggestions welcome.