### PR TITLE
Fix result onerror

### DIFF
--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -16,7 +16,7 @@ class CeleryProgressBar {
         this.onIgnored = options.onIgnored || this.onIgnoredDefault;
         let resultElementId = options.resultElementId || 'celery-result';
         this.resultElement = options.resultElement || document.getElementById(resultElementId);
-        this.onResult = options.onResult || CeleryProgressBar.onResultDefault;
+        this.onResult = options.onResult || this.onResultDefault;
         // HTTP options
         this.onNetworkError = options.onNetworkError || this.onError;
         this.onHttpError = options.onHttpError || this.onError;
@@ -36,7 +36,7 @@ class CeleryProgressBar {
         progressBarMessageElement.textContent = "Success! " + result;
     }
 
-    static onResultDefault(resultElement, result) {
+    onResultDefault(resultElement, result) {
         if (resultElement) {
             resultElement.textContent = result;
         }

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -10,7 +10,7 @@ class CeleryProgressBar {
         this.onProgress = options.onProgress || this.onProgressDefault;
         this.onSuccess = options.onSuccess || this.onSuccessDefault;
         this.onError = options.onError || this.onErrorDefault;
-        this.onTaskError = options.onTaskError || this.onError;
+        this.onTaskError = options.onTaskError || this.onTaskErrorDefault;
         this.onDataError = options.onDataError || this.onError;
         this.onRetry = options.onRetry || this.onRetryDefault;
         this.onIgnored = options.onIgnored || this.onIgnoredDefault;
@@ -52,10 +52,15 @@ class CeleryProgressBar {
         progressBarMessageElement.textContent = "Uh-Oh, something went wrong! " + excMessage;
     }
 
+    onTaskErrorDefault(progressBarElement, progressBarMessageElement, excMessage) {
+        let message = this.getMessageDetails(excMessage);
+        this.onError(progressBarElement, progressBarMessageElement, message);
+    }
+
     onRetryDefault(progressBarElement, progressBarMessageElement, excMessage, retryWhen) {
         retryWhen = new Date(retryWhen);
         let message = 'Retrying in ' + Math.round((retryWhen.getTime() - Date.now())/1000) + 's: ' + excMessage;
-        this.onTaskError(progressBarElement, progressBarMessageElement, message);
+        this.onError(progressBarElement, progressBarMessageElement, message);
     }
 
     onIgnoredDefault(progressBarElement, progressBarMessageElement, result) {
@@ -105,7 +110,7 @@ class CeleryProgressBar {
                     done = false;
                     delete data.result;
                 } else {
-                    this.onTaskError(this.progressBarElement, this.progressBarMessageElement, this.getMessageDetails(data.result));
+                    this.onTaskError(this.progressBarElement, this.progressBarMessageElement, data.result);
                 }
             } else {
                 if (data.state === 'IGNORED') {


### PR DESCRIPTION
Fixes the onError part of https://github.com/czue/celery-progress/issues/66.

Also makes make onResultDefault an instance method following the discussion in https://github.com/czue/celery-progress/pull/62.