### PR TITLE
Add never_cache Decorator to get_progress View

### DIFF
--- a/celery_progress/views.py
+++ b/celery_progress/views.py
@@ -2,8 +2,9 @@ import json
 from django.http import HttpResponse
 from celery.result import AsyncResult
 from celery_progress.backend import Progress
+from django.views.decorators.cache import never_cache
 
-
+@never_cache
 def get_progress(request, task_id):
     progress = Progress(AsyncResult(task_id))
     return HttpResponse(json.dumps(progress.get_info()), content_type='application/json')


### PR DESCRIPTION
When "django.middleware.cache.FetchFromCacheMiddleware" is included in MIDDLEWARE it ends up caching the get_progress view, which is not ideal since the idea for get_progress is to periodically provide updates to the client about task status.  Adding the @never_cache decorator prevents django from caching this view.

Fixxes Issue #70 