### PR TITLE
Log and print unknown state

### DIFF
--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -109,7 +109,7 @@ class Progress(object):
                 'complete': True,
                 'success': False,
                 'progress': _get_unknown_progress(self.result.state),
-                'result': 'Unknown state {}: {}'.format(self.result.state, str(self.result.info)),
+                'result': 'Unknown state {}'.format(self.result.state),
             })
         return response
 

--- a/celery_progress/backend.py
+++ b/celery_progress/backend.py
@@ -1,10 +1,12 @@
 import datetime
+import logging
 from abc import ABCMeta, abstractmethod
 from decimal import Decimal
 
 from celery.result import EagerResult, allow_join_result
 from celery.backends.base import DisabledBackend
 
+logger = logging.getLogger(__name__)
 
 PROGRESS_STATE = 'PROGRESS'
 
@@ -102,11 +104,12 @@ class Progress(object):
                 'progress': _get_unknown_progress(self.result.state),
             })
         else:
+            logger.error('Task %s has unknown state %s with metadata %s', self.result.id, self.result.state, self.result.info)
             response.update({
                 'complete': True,
                 'success': False,
                 'progress': _get_unknown_progress(self.result.state),
-                'result': 'Unknown state {}'.format(str(self.result.info)),
+                'result': 'Unknown state {}: {}'.format(self.result.state, str(self.result.info)),
             })
         return response
 


### PR DESCRIPTION
This makes it easier to diagnose issues with unknown states like #80 (states that aren't currently handled by celery-progress).

The unknown state will be:
1. logged like "Task ed4147aa-0e33-43a9-9f04-347571d3c162 has unknown state CUSTOM with metadata None".
2. shown in the progress bar error message like "Uh-Oh, something went wrong! Unknown state CUSTOM".