### PR TITLE
Update Classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Dropping compatibility to Django 1.11 because of the import of re_path in celery-progress/urls.py that is available only on Django's version >=2.0