### PR TITLE
Allow default colors to be accessed without class instantiation

### DIFF
--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -170,7 +170,7 @@ class CeleryProgressBar {
             error: '#dc4f63',
             progress: '#68a9ef',
             ignored: '#7a7a7a'
-        }
+        };
     }
 
     static initProgressBar(progressUrl, options) {

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -22,13 +22,7 @@ class CeleryProgressBar {
         this.onHttpError = options.onHttpError || this.onError;
         this.pollInterval = options.pollInterval || 500;
         // Other options
-        let barColorsDefault = {
-            success: '#76ce60',
-            error: '#dc4f63',
-            progress: '#68a9ef',
-            ignored: '#7a7a7a'
-        }
-        this.barColors = Object.assign({}, barColorsDefault, options.barColors);
+        this.barColors = Object.assign({}, getBarColorsDefault(), options.barColors);
 
         let defaultMessages = {
             waiting: 'Waiting for task to start...',
@@ -167,6 +161,15 @@ class CeleryProgressBar {
             }
         } else {
             this.onHttpError(this.progressBarElement, this.progressBarMessageElement, "HTTP Code " + response.status, response);
+        }
+    }
+    
+    static getBarColorsDefault() {
+        return {
+            success: '#76ce60',
+            error: '#dc4f63',
+            progress: '#68a9ef',
+            ignored: '#7a7a7a'
         }
     }
 

--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -22,7 +22,7 @@ class CeleryProgressBar {
         this.onHttpError = options.onHttpError || this.onError;
         this.pollInterval = options.pollInterval || 500;
         // Other options
-        this.barColors = Object.assign({}, getBarColorsDefault(), options.barColors);
+        this.barColors = Object.assign({}, this.getBarColorsDefault(), options.barColors);
 
         let defaultMessages = {
             waiting: 'Waiting for task to start...',


### PR DESCRIPTION
I think this change would help people who want to write custom methods, but still make use of the default colors without having to create a dummy instance just to have access to it.