### PR TITLE
Changed url to re_path for compatibility with Django >= 4.

### DIFF
--- a/celery_progress/websockets/routing.py
+++ b/celery_progress/websockets/routing.py
@@ -1,4 +1,8 @@
-from django.conf.urls import url
+try:
+    from django.conf.urls import url
+    re_path = url
+except ImportError:
+    from django.urls import re_path
 
 from celery_progress.websockets import consumers
 
@@ -8,5 +12,5 @@ except AttributeError:
     progress_consumer = consumers.ProgressConsumer  # Channels 3 not installed, revert to Channels 2 behavior
 
 urlpatterns = [
-    url(r'^ws/progress/(?P<task_id>[\w-]+)/?$', progress_consumer),
+    re_path(r'^ws/progress/(?P<task_id>[\w-]+)/?$', progress_consumer),
 ]


### PR DESCRIPTION
The url function was deprecated in Django 3 and removed in Django 4. I have left the import for older installs. It's the only crash I had so far with Django 4.1.5.