### PR TITLE
fix: Change retry logic to extract next run from traceback

### DIFF
--- a/celery_progress/static/celery_progress/celery_progress.js
+++ b/celery_progress/static/celery_progress/celery_progress.js
@@ -65,7 +65,8 @@ class CeleryProgressBar {
     onRetryDefault(progressBarElement, progressBarMessageElement, excMessage, retryWhen) {
         retryWhen = new Date(retryWhen);
         let message = 'Retrying in ' + Math.round((retryWhen.getTime() - Date.now())/1000) + 's: ' + excMessage;
-        this.onError(progressBarElement, progressBarMessageElement, message);
+        progressBarElement.style.backgroundColor = this.barColors.error;
+        progressBarMessageElement.textContent =  message;
     }
 
     onIgnoredDefault(progressBarElement, progressBarMessageElement, result) {
@@ -163,7 +164,7 @@ class CeleryProgressBar {
             this.onHttpError(this.progressBarElement, this.progressBarMessageElement, "HTTP Code " + response.status, response);
         }
     }
-    
+
     static getBarColorsDefault() {
         return {
             success: '#76ce60',


### PR DESCRIPTION
`task_meta.result` is an Exception for me with Celery v5.2.5, I can't grasp where result.when would come from. The retry logic simply does not work as the result is an Exception and does not have any fields indicating when the next run is. Accessing `when` just crashes the progress bar and returns a 500 error.

Still kept it in and checked if it's iterable, maybe it works for others.

Here's a PR that works for me, if there's other solutions let me know. But atm retries are causing 500 errors.